### PR TITLE
Remove puts output from `head`

### DIFF
--- a/proxmark3.rb
+++ b/proxmark3.rb
@@ -4,7 +4,6 @@ class Proxmark3 < Formula
 #  url "https://github.com/RfidResearchGroup/proxmark3/archive/xxxx.tar.gz"
 #  sha256 "bc19f98c661304db5a79e07b44b2f16ef5229b490985dc1d87e6f494a6729558"
   head do
-    puts "env variable TRAVIS_COMMIT: `#{ENV['HOMEBREW_TRAVIS_COMMIT']}`"
     if ENV.has_key?('HOMEBREW_TRAVIS_COMMIT')
       url "https://github.com/RfidResearchGroup/proxmark3.git", :branch => "#{ENV['HOMEBREW_TRAVIS_BRANCH']}", :revision => "#{ENV['HOMEBREW_TRAVIS_COMMIT']}"
     else


### PR DESCRIPTION
Having output in the `head` can cause `brew bundle` to break. For example, I've got an application setup locally which loads formulas into to JSON via `brew bundle`. Since I had this formula tapped when loaded it would output via `puts` the `TRAVIS_COMMIT` env variable into the output making the json invalid causing the application setup via `brew bundle` to fail.