### PR TITLE
Support additional build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,36 @@ The old HID-flasher doesn't compile on this version. You'll need to manually fix
 - Tap this repo: `brew tap rfidresearchgroup/proxmark3`
 
 - Install Proxmark3:
-  - (Optional) `export HOMEBREW_PROXMARK3_PLATFORM=xxxxxx` to specify [platform](https://github.com/RfidResearchGroup/proxmark3/blob/master/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md#platform), default value is `PM3RDV4` if none
-     - `export HOMEBREW_PROXMARK3_PLATFORM=PM3GENERIC` == For all other Proxmark3 devices (non RDV4)
   - `brew install proxmark3` for stable release 
   - `brew install --HEAD proxmark3` for latest non-stable from GitHub (use this if previous command fails)
   - `brew install --with-blueshark proxmark3` for blueshark support, stable release
   - `brew install --HEAD --with-blueshark proxmark3` for blueshark support, latest non-stable from GitHub (use this if previous command fails)
+
+### Build options
+
+Use `brew info proxmark3` to see all available options.
+
+#### Platform selection
+
+Firmware is built for the Proxmark3 RDV4 device by default. Use the following options to select other platforms:
+
+- `--with-generic`: build for generic (non-RDV4) devices, see [platform](https://github.com/RfidResearchGroup/proxmark3/blob/master/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md#platform).
+- `--with-small`: enable build-time size limit for devices with 256kB flash, see [256kb versions](https://github.com/RfidResearchGroup/proxmark3/blob/master/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md#256kb-versions).
+
+#### Removing features
+
+When installing with `--HEAD`, it's possible to remove features to reduce firmware size for 256kB devices using options such as `--without-lf`, `--without-hitag`, etc.
+
+`--without-foo` corresponds to the `SKIP_FOO` compile options listed [here](https://github.com/RfidResearchGroup/proxmark3/blob/master/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md#256kb-versions).
+
+#### Standalone mode
+
+Firmware is built with the `HF_MSDSAL` standalone mode by default. Use the `--with-lf-foo` or `--with-hf-foo` options to select a different standalone mode,
+or `--without-standalone` to disable standalone mode altogether.
+
+`--with-lf-foo` corresponds to the `STANDALONE=LF_FOO` compile options listed [here](https://github.com/RfidResearchGroup/proxmark3/blob/master/doc/md/Use_of_Proxmark/4_Advanced-compilation-parameters.md#standalone).
+
+Some of these options will only work with `--HEAD`.
 
 ### Errors while running
 

--- a/proxmark3.rb
+++ b/proxmark3.rb
@@ -3,6 +3,7 @@ class Proxmark3 < Formula
   homepage "http://www.proxmark.org/"
   url "https://github.com/RfidResearchGroup/proxmark3/archive/v4.9237.tar.gz"
   sha256 "db93c2d3b9b7f477aca5628ed0906d9dba9c1999080452b24c601f38ab5b5226"
+
   head do
     if ENV.has_key?('HOMEBREW_TRAVIS_COMMIT')
       url "https://github.com/RfidResearchGroup/proxmark3.git", :branch => "#{ENV['HOMEBREW_TRAVIS_BRANCH']}", :revision => "#{ENV['HOMEBREW_TRAVIS_COMMIT']}"
@@ -10,29 +11,68 @@ class Proxmark3 < Formula
       url "https://github.com/RfidResearchGroup/proxmark3.git"
     end
   end
-  
+
   depends_on "readline"
   depends_on "pkg-config" => :build
-  depends_on "qt5"
-  depends_on "RfidResearchGroup/proxmark3/arm-none-eabi-gcc" => :build
+  depends_on "qt5" => :recommended
+  depends_on "./arm-none-eabi-gcc" => :build
 
   option "with-blueshark", "Enable Blueshark (BT Addon) support"
+  option 'with-generic', 'Build for generic devices instead of RDV4'
+  option 'with-small', 'Build for 256kB devices (HEAD only)'
+
+  FUNCTIONS = %w[em4x50 felica hfplot hfsniff hitag iclass iso14443a iso14443b iso15693 legicrf lf nfcbarcode]
+  STANDALONE = {
+    'lf' => %w[em4100emul em4100rswb em4100rwc hidbrute icehid proxbrute samyrun skeleton tharexde],
+    'hf' => %w[14asniff aveful bog craftbyte colin iceclass legic mattyrun tcprst tmudford young]
+  }
+
+  FUNCTIONS.each do |func|
+    option "without-#{func}", "Build without #{func.upcase} functionality (HEAD only)"
+  end
+
+  option 'without-standalone', 'Build without standalone mode'
+
+  STANDALONE.each do |freq, modes|
+    modes.each do |mode|
+      option "with-#{freq}-#{mode}", "Build with standalone mode #{freq.upcase}_#{mode.upcase}"
+    end
+  end
 
   def install
     ENV.deparallelize
 
-    if not ENV.has_key?('HOMEBREW_PROXMARK3_PLATFORM')
-      ENV['HOMEBREW_PROXMARK3_PLATFORM'] = 'PM3RDV4'
+    args = %W[
+      BREW_PREFIX=#{HOMEBREW_PREFIX}
+      PLATFORM=#{build.with?('generic') ? (build.head? ? 'PM3GENERIC' : 'PM3OTHER') : 'PM3RDV4'}
+    ]
+
+    args << 'PLATFORM_EXTRAS=BTADDON' if build.with? 'blueshark'
+    args << 'PLATFORM_SIZE=256' if build.with? 'small'
+    args << 'SKIPQT=1' unless build.with? 'qt5'
+
+    if build.head?
+      FUNCTIONS.each do |func|
+        args << "SKIP_#{func.upcase}=1" unless build.with? func
+      end
     end
 
-    system "make", "clean"
-    if build.with? "blueshark"
-      system "make", "all", "PLATFORM=#{ENV['HOMEBREW_PROXMARK3_PLATFORM']}", "PLATFORM_EXTRAS=BTADDON", "BREW_PREFIX=#{HOMEBREW_PREFIX}"
-      system "make", "install", "PREFIX=#{prefix}", "PLATFORM=#{ENV['HOMEBREW_PROXMARK3_PLATFORM']}", "PLATFORM_EXTRAS=BTADDON", "BREW_PREFIX=#{HOMEBREW_PREFIX}"
-    else
-      system "make", "all", "PLATFORM=#{ENV['HOMEBREW_PROXMARK3_PLATFORM']}", "BREW_PREFIX=#{HOMEBREW_PREFIX}"
-      system "make", "install", "PREFIX=#{prefix}", "PLATFORM=#{ENV['HOMEBREW_PROXMARK3_PLATFORM']}", "BREW_PREFIX=#{HOMEBREW_PREFIX}"
+    standalone = build.with?('standalone') ? nil : ''
+
+    STANDALONE.each do |freq, modes|
+      modes.each do |mode|
+        if build.with? "#{freq}-#{mode}"
+          odie 'Only one standalone mode may be selected' unless standalone.nil?
+          standalone = "#{freq.upcase}_#{mode.upcase}"
+        end
+      end
     end
+
+    args << "STANDALONE=#{standalone}" unless standalone.nil?
+
+    system "make", "clean"
+    system "make", "all", *args
+    system "make", "install", "PREFIX=#{prefix}", *args
 
     ohai "Install success!"
     ohai "The latest bootloader and firmware binaries are ready and waiting in the current homebrew Cellar within share/firmware."


### PR DESCRIPTION
Allow specifying build options when installing, e.g.:

```
$ brew install --HEAD --with-generic --with-small --without-standalone --without-hitag proxmark3
==> Installing proxmark3 from cynix/proxmark3
==> Cloning https://github.com/RfidResearchGroup/proxmark3.git
Updating /Users/cynix/Library/Caches/Homebrew/proxmark3--git
==> Checking out branch master
Already on 'master'
Your branch is up to date with 'origin/master'.
HEAD is now at 30fc94da4 Merge pull request #1275 from tharexde/fix_4x50_standalone
==> make clean
==> make all BREW_PREFIX=/usr/local PLATFORM=PM3GENERIC PLATFORM_SIZE=256 SKIP_HITAG=1 STANDALONE=
==> make install PREFIX=/usr/local/Cellar/proxmark3/HEAD-30fc94d BREW_PREFIX=/usr/local PLATFORM=PM3GENERIC PLATFORM_SIZE=256 SKIP_HITAG=1 STANDALONE=
==> Install success!
==> The latest bootloader and firmware binaries are ready and waiting in the current homebrew Cellar within share/firmware.
🍺  /usr/local/Cellar/proxmark3/HEAD-30fc94d: 680 files, 41.3MB, built in 1 minute 45 seconds
```