### PR TITLE
Fixed url with correct version

### DIFF
--- a/proxmark3.rb
+++ b/proxmark3.rb
@@ -1,7 +1,7 @@
 class Proxmark3 < Formula
   desc "RRG/Iceman Proxmark3 client, CDC flasher and firmware bundle"
   homepage "http://www.proxmark.org/"
-  url "https://github.com/RfidResearchGroup/proxmark3/archive/refs/tags/v4.18340.tar.gz"
+  url "https://github.com/RfidResearchGroup/proxmark3/archive/refs/tags/v4.18341.tar.gz"
   sha256 "f22b0bbebc02dcb6a99ac3ba69f3035afdd6f068fcdb759ca5eac85fee0a77ce"
 
   head do


### PR DESCRIPTION
URL used v4.18340. Changed to v4.18341.