### PR TITLE
Added Lua as dependency

### DIFF
--- a/proxmark3.rb
+++ b/proxmark3.rb
@@ -14,6 +14,7 @@ class Proxmark3 < Formula
 
   depends_on "readline"
   depends_on "coreutils"
+  depends_on "lua" => :build
   depends_on "pkg-config" => :build
   depends_on "openssl@3" => :build
   depends_on "qt5" => :recommended


### PR DESCRIPTION
This patch resolves an issue where a global Lua installation led the Makefile to attempt using the global installation, resulting in a failure since it wasn’t considered a build dependency by Homebrew. Consequently, the patch ensures that Lua is always included as an external dependency managed by Homebrew, rather than relying on the lib included in the proxmark3 repository.