### PR TITLE
Fix Qt dependency option check

### DIFF
--- a/proxmark3.rb
+++ b/proxmark3.rb
@@ -77,7 +77,7 @@ class Proxmark3 < Formula
       SKIP_ZX8211=1
       SKIP_LEGICRF=1     
       ' if build.with? 'small'
-    args << 'SKIPQT=1' unless build.with? 'qt5'
+    args << 'SKIPQT=1' unless build.with? 'qt@5'
 
     FUNCTIONS.each do |func|
       args << "SKIP_#{func.upcase}=1" unless build.with? func


### PR DESCRIPTION
## Summary

- Check the recommended Qt dependency using its actual Homebrew option name, `qt@5`.
- Allow default builds to retain Qt waveform support instead of adding `SKIPQT=1`.

## Root cause

The formula declares `depends_on "qt@5" => :recommended`, which creates the `with-qt@5` build option, but the install logic checks `build.with? "qt5"`.

That check is false even when the recommended dependency is enabled, so the formula adds `SKIPQT=1` and builds the client without Qt waveform support.

## Validation

- `ruby -c proxmark3.rb`
- `brew style proxmark3.rb`
- `brew audit --strict proxmark3.rb`
- Reinstalled Proxmark3 `v4.21611` from source with `--with-generic` on Apple silicon macOS
- Confirmed the installed client links Qt Widgets, GUI, and Core
- Confirmed `data plot` is available
